### PR TITLE
[fix] send comment to correct layer of comments

### DIFF
--- a/src/FacebookContext.js
+++ b/src/FacebookContext.js
@@ -18,7 +18,9 @@ export default class FacebookContext extends MessengerContext {
 
   // https://developers.facebook.com/docs/graph-api/reference/v3.1/object/comments/
   sendComment(message) {
-    const objectId = this._event.rawEvent.value.comment_id; // FIXME: postId
+    const objectId = this._event.isFirstLayerComment
+      ? this._event.rawEvent.value.comment_id
+      : this._event.rawEvent.value.parent_id; // FIXME: postId
 
     if (this._event.isSentByPage) {
       warning(false, 'Could not sendComment to page itself.');

--- a/src/__tests__/FacebookContext.spec.js
+++ b/src/__tests__/FacebookContext.spec.js
@@ -56,13 +56,42 @@ const setup = ({ rawEvent, pageId } = { rawEvent: userRawEvent }) => {
 };
 
 describe('#sendComment', () => {
-  it('should call client with comment id', async () => {
-    const { context, client } = setup();
+  it('should call client with comment id, when incoming comment is a first layer comment', async () => {
+    const { context, client } = setup({
+      rawEvent: {
+        field: 'feed',
+        value: {
+          from: {
+            id: '139560936744123',
+            name: 'user',
+          },
+          item: 'comment',
+          comment_id: '139560936744456_139620233405726',
+          post_id: '137542570280222_139560936744456',
+          verb: 'add',
+          parent_id: '137542570280222_139560936744456',
+          created_time: 1511951015,
+          message: 'OK',
+        },
+      },
+    });
 
     await context.sendComment('Public Reply!');
 
     expect(client.sendComment).toBeCalledWith(
       '139560936744456_139620233405726',
+      'Public Reply!',
+      { access_token: undefined }
+    );
+  });
+
+  it('should call client with parent id, when the incoming comment is not a first layer comment', async () => {
+    const { context, client } = setup();
+
+    await context.sendComment('Public Reply!');
+
+    expect(client.sendComment).toBeCalledWith(
+      '139560936744456_139562213411528',
       'Public Reply!',
       { access_token: undefined }
     );


### PR DESCRIPTION
should send comment to the comment's parent when it is not a first layer comment