### PR TITLE
fix getting wrong page id when receiving batch request

### DIFF
--- a/src/__tests__/FacebookConnector.spec.js
+++ b/src/__tests__/FacebookConnector.spec.js
@@ -37,7 +37,7 @@ const request = {
   },
 };
 
-const batchRequest = {
+const differentPagebatchRequest = {
   body: {
     object: 'page',
     entry: [
@@ -63,6 +63,54 @@ const batchRequest = {
       },
       {
         id: '189538289069256',
+        time: 1486464322257,
+        messaging: [
+          {
+            sender: {
+              id: '1412611362105802',
+            },
+            recipient: {
+              id: '189538289069256',
+            },
+            timestamp: 1486464322190,
+            message: {
+              mid: 'mid.1486464322190:cb04e5a656',
+              seq: 339979,
+              text: 'test 2',
+            },
+          },
+        ],
+      },
+    ],
+  },
+};
+
+const samePageBatchRequest = {
+  body: {
+    object: 'page',
+    entry: [
+      {
+        id: '1895382890692545',
+        time: 1486464322257,
+        messaging: [
+          {
+            sender: {
+              id: '1412611362105802',
+            },
+            recipient: {
+              id: '1895382890692545',
+            },
+            timestamp: 1486464322190,
+            message: {
+              mid: 'mid.1486464322190:cb04e5a654',
+              seq: 339979,
+              text: 'test 1',
+            },
+          },
+        ],
+      },
+      {
+        id: '1895382890692545',
         time: 1486464322257,
         messaging: [
           {
@@ -137,6 +185,28 @@ const commentAddRequest = {
           },
         ],
       },
+      {
+        id: '<OTHER_PAGE_ID>',
+        time: 1458692752478,
+        changes: [
+          {
+            field: 'feed',
+            value: {
+              from: {
+                id: '139560936744123',
+                name: 'user',
+              },
+              item: 'comment',
+              comment_id: '139560936744456_139620233405726',
+              post_id: '137542570280222_139560936744456',
+              verb: 'add',
+              parent_id: '139560936744456_139562213411528',
+              created_time: 1511951015,
+              message: 'Good',
+            },
+          },
+        ],
+      },
     ],
   },
 };
@@ -175,15 +245,26 @@ describe('#mapRequestToEvents', () => {
     expect(events[0].pageId).toBe('1895382890692545');
   });
 
-  it('should work with batch entry', () => {
+  it('should work with batch entry from same page', () => {
     const { connector } = setup();
-    const events = connector.mapRequestToEvents(batchRequest.body);
+    const events = connector.mapRequestToEvents(samePageBatchRequest.body);
 
     expect(events).toHaveLength(2);
     expect(events[0]).toBeInstanceOf(FacebookEvent);
     expect(events[0].pageId).toBe('1895382890692545');
     expect(events[1]).toBeInstanceOf(FacebookEvent);
+    expect(events[1].pageId).toBe('1895382890692545');
+  });
+
+  it('should work with batch entry from different page', () => {
+    const { connector } = setup();
+    const events = connector.mapRequestToEvents(differentPagebatchRequest.body);
+
+    expect(events).toHaveLength(2);
+    expect(events[0]).toBeInstanceOf(FacebookEvent);
     expect(events[0].pageId).toBe('1895382890692545');
+    expect(events[1]).toBeInstanceOf(FacebookEvent);
+    expect(events[1].pageId).toBe('189538289069256');
   });
 
   it('should map request to standby FacebookEvents', () => {
@@ -200,10 +281,13 @@ describe('#mapRequestToEvents', () => {
     const { connector } = setup();
     const events = connector.mapRequestToEvents(commentAddRequest.body);
 
-    expect(events).toHaveLength(1);
+    expect(events).toHaveLength(2);
     expect(events[0]).toBeInstanceOf(FacebookEvent);
     expect(events[0].pageId).toBe('<PAGE_ID>');
     expect(events[0].isStandby).toBe(false);
+    expect(events[1]).toBeInstanceOf(FacebookEvent);
+    expect(events[1].pageId).toBe('<OTHER_PAGE_ID>');
+    expect(events[1].isStandby).toBe(false);
   });
 
   it('should be filtered if body is not messaging or standby', () => {


### PR DESCRIPTION
when receiving batch request like 
```
{
  body: {
    object: 'page',
    entry: [
      {
        id: '<PAGE_ID>',
        time: 1458692752478,
        changes: [
          {
            field: 'feed',
            value: {
              from: {
                id: '139560936744123',
                name: 'user',
              },
              item: 'comment',
              comment_id: '139560936744456_139620233405726',
              post_id: '137542570280222_139560936744456',
              verb: 'add',
              parent_id: '139560936744456_139562213411528',
              created_time: 1511951015,
              message: 'Good',
            },
          },
        ],
      },
      {
        id: '<OTHER_PAGE_ID>',
        time: 1458692752478,
        changes: [
          {
            field: 'feed',
            value: {
              from: {
                id: '139560936744123',
                name: 'user',
              },
              item: 'comment',
              comment_id: '139560936744456_139620233405726',
              post_id: '137542570280222_139560936744456',
              verb: 'add',
              parent_id: '139560936744456_139562213411528',
              created_time: 1511951015,
              message: 'Good',
            },
          },
        ],
      },
    ],
  },
}
```

currently we will create two facebookEvent both containing pageId: '<PAGE_ID>',
this pr should fix this issue.